### PR TITLE
Don't delete .nojekyll

### DIFF
--- a/pbb
+++ b/pbb
@@ -350,7 +350,7 @@ deploy() {
 	fi
 
 	git checkout master
-	rm --recursive --force !(@(artifacts|CNAME))
+	rm --recursive --force !(@(artifacts|CNAME|.nojekyll))
 	cp --recursive artifacts/* .
 	rm --recursive --force artifacts
 	git add --all


### PR DESCRIPTION
The .nojekyll file indicates that the default GitHub Actions workflow to build pages shouldn't run Jekyll, as it is redundant: the page is already built.

The file should probably be generated as part of `pbb init`, but that can be taken care of when moving to a model where the publishing source is a directory.