### PR TITLE
Add Atom feed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Pandoc
         uses: r-lib/actions/setup-pandoc@v2.6.4
         with:
-          pandoc-version: 2.19.2
+          pandoc-version: 3.1.6.1
 
       - name: Get Bats repository
         uses: actions/checkout@v3.5.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v3.5.3
         with:
           repository: bats-core/bats-core
-          ref: v1.7.0
+          ref: v1.10.0
           path: bats-core
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   test:
-    name: Run BATS tests
+    name: Run Bats tests
     runs-on: ubuntu-22.04
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ install:
 	$(call checkdep,Python 3,python)
 	$(call checkdep,Bats,bats)
 	$(call checkdep,dot,dot)
+	$(call checkdep,yq,yq)
 	$(call doinstall,pbb,pbb,$(binpath))
 	$(call doinstall,stylesheet,assets/pbb.css,$(csspath))
 	$(call doinstall,calendar icon,assets/calendar.svg,$(iconpath))

--- a/README.md
+++ b/README.md
@@ -55,23 +55,24 @@ for older versions. `make install` checks if the executables exist, but not
 their versions.
 
 - Bash 5.1.16
-- Pandoc 2.19.2
-- Git 2.37.3
+- Pandoc 3.1.6.1
+- Git 2.41.0
 - GNU Coreutils 8.32: `cat`, `cp`, `mkdir`, `ln`, `rm`, `tac`
 - GNU Sed 4.8
 - ImageMagick 6.9.11-60 (for favicon)
-- Python 3.10.4 (for `pbb serve`)
+- Python 3.10.12 (for `pbb serve`)
 - `inotifywait` from inotify-tools 3.22.1.0 (for hot-reloading during `pbb
   serve`)
-- Bats 1.7.0 (for test suite)
+- Bats 1.10.0 (for test suite)
 - bash-completion 2.11 (for tab completion)
 - graphviz 2.43.0 (for dot graphs)
+- yq 4.34.2
 
 In the Makefile, additionally:
 
 - GNU Make 4.3
 - GNU Awk 5.1.0
-- `column` from util-linux 2.38.2
+- `column` from util-linux 2.37.2
 - GNU Coreutils 8.32: `install`, `rmdir`
 
 ## Usage
@@ -88,17 +89,31 @@ pbb init 'My blog'
 If you later want to change the title, use
 
 ```bash
-pbb title 'My blog with a new title'
+pbb set title 'My blog with a new title'
 ```
 
 `pbb init` creates a sample blog post. Blog posts are written in [Pandoc
 Markdown] (see also [my post about it]), with filenames formatted like
 `YYYY-MM-DD-post-title.md`.
 
-The first heading of a post has to be a level-one heading:
+The first heading of a post has to be a level-one heading, and the summary is
+what'll appear in the Atom feed:
 
 ```markdown
+---
+summary: >-
+  The summary for the Atom feed
+---
+
 # A blog post
+```
+
+To configure some global values for the Atom feed, set them with `pbb set`:
+
+```bash
+pbb set authorname 'Billy Bishop'
+pbb set authoremail 'billy@example.com'
+pbb set baseurl 'https://someblogurl.ca'
 ```
 
 Images must be stored in the `images` directory.
@@ -126,18 +141,18 @@ You might have to set the Git remote first:
 git remote add origin https://github.com/<yourname>/<repo-name>.git
 ```
 
-[Pandoc Markdown]: <https://pandoc.org/MANUAL.html#pandocs-markdown>
+[pandoc markdown]: <https://pandoc.org/MANUAL.html#pandocs-markdown>
 [my post about it]: <https://benjaminwuethrich.dev/2020-05-04-everything-pandoc-markdown.html>
 
 ### Table of contents
 
-To get a table of contents for a post, start it with a YAML document that sets
-the `toc` variable to `true`:
+To get a table of contents for a post, set `toc` to `true` in the YAML front
+matter:
 
 ```yaml
 ---
 toc: true
-...
+---
 ```
 
 ### Math
@@ -219,11 +234,11 @@ produces
 
 > Nice shoes! :lying_face:
 
-[ghemoji]: <https://github.com/ikatyang/emoji-cheat-sheet/blob/master/README.md>
+[ghemoji]: <https://github.com/ikatyang/emoji-cheat-sheet>
 
 ## Subcommands
 
-There are eight subcommands (nine, if you count `pbb help`); when properly
+There are seven subcommands (eight, if you count `pbb help`); when properly
 installed, they should tab-autocomplete.
 
 ### `pbb init <title>`
@@ -235,9 +250,29 @@ installed, they should tab-autocomplete.
   title link, favicon, Google web font links and GoatCounter analytics
 - Creates an example post
 
-### `pbb title <new title>`
+### `pbb set <property> <value>`
+
+```sh
+pbb set title <new title>
+```
 
 - Sets a new blog title for an existing blog
+
+```sh
+pbb set gccode <code>
+```
+
+- Includes a snippet with tracking code for [GoatCounter] on each page, where
+  the code for the account is `<code>`
+- To turn tracking off, set code to empty with `pbb gccode ''`
+
+```sh
+pbb set authorname <author name>
+pbb set authoremali <author email>
+pbb set baseurl <blog base URL>
+```
+
+- Sets global values used in Atom feed
 
 ### `pbb enable <feature>`
 
@@ -248,12 +283,6 @@ installed, they should tab-autocomplete.
 
 - Turns off a feature
 
-### `pbb gccode <code>`
-
-- Includes a snippet with tracking code for [GoatCounter] on each page, where
-  the code for the account is `<code>`
-- To turn tracking off, set code to empty with `pbb gccode ''`
-
 ### `pbb build`
 
 - Cleans the `docs` directory, then copies the `images` directory in there
@@ -262,6 +291,7 @@ installed, they should tab-autocomplete.
 - Generates the index file, `index.md`
 - Converts the markdown files with datestamps in their names and `index.md` to
   HTML, copies the results into `docs`
+- Generates an Atom feed for the up to ten most recent posts at `docs/feed.xml`
 
 ### `pbb serve`
 

--- a/assets/pbb.css
+++ b/assets/pbb.css
@@ -28,6 +28,10 @@ div.index-title p {
 	margin: initial;
 }
 
+h1.title {
+	font-size: 2.2em;
+}
+
 a {
 	outline: none;
 	-wekbit-tap-highlight-color: transparent;

--- a/completion/pbb
+++ b/completion/pbb
@@ -12,8 +12,7 @@ _pbb() {
 			local subcmds=(
 				'help'
 				'init'
-				'title'
-				'gccode'
+				'set'
 				'build'
 				'serve'
 				'deploy'
@@ -28,6 +27,10 @@ _pbb() {
 				enable|disable)
 					local features=('bibliography' 'math')
 					COMPREPLY=($(compgen -W '"${features[@]}"' -- "$cur"))
+					;;
+				set)
+					local properties=('title' 'gccode' 'baseurl' 'authorname' 'authoremail')
+					COMPREPLY=($(compgen -W '"${properties[@]}"' -- "$cur"))
 					;;
 				*)
 					return

--- a/man/pbb.1
+++ b/man/pbb.1
@@ -1,5 +1,5 @@
 .\" ============================================================================
-.TH PBB 1 2022-09-09
+.TH PBB 1 2023-08-10
 .\" ============================================================================
 .SH NAME
 pbb \- Pandoc Bash Blog
@@ -8,17 +8,14 @@ pbb \- Pandoc Bash Blog
 .B pbb init
 .I TITLE
 .br
-.B pbb title
-.I TITLE
+.B pbb set 
+.I PROPERTY VALUE
 .br
 .B pbb enable
 .I FEATURE
 .br
 .B pbb disable
 .I FEATURE
-.br
-.B pbb gccode
-.I CODE
 .br
 .B pbb build
 .br
@@ -58,7 +55,9 @@ directory, creates the header files to be used on every page in the
 .I includes
 directory, generates the
 .I .metadata.yml
-file, and creates an example post with the current date.
+and
+.I .pbbconfig
+files, and creates an example post with the current date.
 .RS
 .PP
 Unquoted whitespace in
@@ -66,10 +65,41 @@ Unquoted whitespace in
 gets squeezed.
 .RE
 .TP
+.BI set\  PROPERTY\ VALUE
+Set
+.I PROPERTY
+to
+.IR VALUE.
+Valid properties are
+.RS
+.TP
 .BI title\  TITLE
 Change the blog title to
 .IR TITLE .
 Unquoted whitespace gets squeezed.
+.TP
+.BI gccode\  CODE
+Include a snippet with tracking code for GoatCounter on each page, where
+.I CODE
+is the code that identifies where you access your GoatCounter account, as in
+.UR https://CODE.goatcounter.com
+.UE .
+.RS
+.PP
+To disable GoatCounter, set the code to the empty string using
+.BR pbb\ gccode\ '' .
+.RE
+.TP
+.BI authorname\  NAME
+.PD 0
+.TP
+.BI authoremail\  EMAIL
+.TP
+.BI baseurl\  URL
+.PD
+Set configuration values used in the Atom feed; the values are stored in
+.IR .pbbconfig .
+.RE
 .TP
 .BI enable\  FEATURE
 .PD 0
@@ -92,18 +122,6 @@ and
 See
 .B OPTIONS
 for details.
-.TP
-.BI gccode\  CODE
-Include a snippet with tracking code for GoatCounter on each page, where
-.I CODE
-is the code that identifies where you access your GoatCounter account, as in
-.UR https://CODE.goatcounter.com
-.UE .
-.RS
-.PP
-To disable GoatCounter, set the code to the empty string using
-.BR pbb\ gccode\ '' .
-.RE
 .TP
 .B build
 Build HTML pages from the provided Markdown input.
@@ -130,6 +148,13 @@ To be processed, a Markdown file has to have a name like
 all these files become separate posts, and a file
 .I index.md
 containing links to all posts is generated to serve as the front page.
+.PP
+For the up to ten most recent posts, an Atom feed is generated using the global
+settings for
+.BR authorname ,\  authoremail ,\ and\  baseurl .
+The summary of each post is taken from the value of the
+.B summary
+YAML front matter for each post.
 .RE
 .TP
 .B serve
@@ -146,23 +171,29 @@ directory, allowing to quickly rebuild a post while working on it and previewing
 it in a browser.
 This is implemented using
 .BR inotifywait (1).
+.RS
+.PP
+Notice that the Atom feed is not updated, so when a change affects the feed,
+.B pbb build
+has to run again for it to be reflected in the feed.
+.RE
 .TP
 .B deploy
 Publish the blog via GitHub Pages.
 This commits all changes in the
-.I artifacts
+.I docs
 directory and pushes to the configured remote.
 .\" ============================================================================
 .SH OPTIONS
 .SS Table of contents
-To generate a table of contents for a post, start the Markdown file with this
-YAML header:
+To generate a table of contents for a post, add this to the YAML front matter of
+the post:
 .PP
 .in +4n
 .EX
 \-\-\-
 toc: true
-\&...
+\-\-\-
 .EE
 .in
 .PP
@@ -228,11 +259,9 @@ digraph G {
 .I .pbbconfig
 Stores configuration settings for the blog such as the blog title and the
 GoatCounter code.
-It should never have to be edited manually; instead, commands such as
-.B pbb title
-and
-.B pbb gccode
-are used to modify its contents.
+It should never have to be edited manually; use
+.B pbb set
+to modify its contents.
 .TP
 .I .metadata.yml
 Stores metadata used by pandoc such as the heading for the table of contents,
@@ -273,8 +302,9 @@ Markdown files:
 .I header.html
 The page header for each post with a link back to the index page.
 .TP
-.I fontlinks.html
-The header links to get the Google Fonts CSS snippets for the fonts used.
+.I headerlinks.html
+The header links to get the Google Fonts CSS snippets for the fonts used, and
+the link to the Atom feed.
 .TP
 .I favicon.html
 The favicon link that gets included if a favicon has been generated.
@@ -328,7 +358,7 @@ To change the title later on, use
 .PP
 .in +4n
 .EX
-pbb title 'My blog with a new title'
+pbb set title 'My blog with a new title'
 .EE
 .in
 .PP
@@ -339,6 +369,11 @@ has generated an example post,
 .PP
 .in +4n
 .EX
+---
+summary: >-
+  A wild post appeared
+---
+
 # My first post
 
 Hello world! :slightly_smiling_face:
@@ -353,12 +388,11 @@ directory.
 To include a dot graph, create a code block with class
 .I dot
 and it wil be replaced with the graph in the output.
-If you want a table of contents for a post, insert a YAML document at the top
-which sets the
+If you want a table of contents for a post, set
 .I toc
-variable to
+to
 .I true
-(see
+in the YAML front matter (see
 .BR OPTIONS ).
 .PP
 To get a favicon, place a picture at
@@ -369,7 +403,17 @@ it.
 To add a GoatCounter tracking code, say,
 .IR CODE ,
 run
-.BR pbb\ gccode\ CODE .
+.BR pbb\ set\ gccode\ CODE .
+.PP
+To set global values for the Atom feed, use
+.PP
+.in +4n
+.EX
+pbb set authorname "Your Name"
+pbb set authoremail you@example.com
+pbb set baseurl https://yourwebsite.com
+.EE
+.in
 .PP
 To enable MathJax, run
 .BR pbb\ enable\ math ,
@@ -394,8 +438,11 @@ git remote add origin https://github.com/<yourname>/<repo-name>.git
 .EE
 .in
 .PP
-Managing version control of the files in the default branch is completely up
-you.
+Managing version control of the blog source files is completely up you, though
+you can mostly let
+.B pbb
+take care of what is in
+.IR docs .
 .\" ============================================================================
 .SH SEE ALSO
 .BR dot (1),\  imagemagick (1),\  inotifywait (1),\  pandoc (1)

--- a/pandoc/dotgraph.lua
+++ b/pandoc/dotgraph.lua
@@ -38,7 +38,7 @@ function createDotGraph(elem)
 	end
 
 	local imgObj = getImgObj(elem, fname)
-	retList:extend({pandoc.Para{imgObj}})
+	retList:extend({imgObj})
 
 	return retList
 end
@@ -53,11 +53,12 @@ end
 
 -- Return a pandoc image object
 function getImgObj(elem, fname)
+	local img = pandoc.Image(elem.attributes.caption or "", fname)
+
 	if not elem.attributes.caption then
-		return pandoc.Image("", fname)
+		return pandoc.Plain{img}
 	end
 
-	-- Trigger a full-blown figure
-	local enableCaption = "fig:"
-	return pandoc.Image(elem.attributes.caption, fname, enableCaption)
+	-- Return a full-blown figure
+	return pandoc.Figure(pandoc.Plain{img}, {elem.attributes.caption})
 end

--- a/pbb
+++ b/pbb
@@ -306,7 +306,7 @@ build() {
 	cp "$calicon" docs/images
 }
 
-# Build Atom feed entry for the provided file
+# Build Atom feed entry for the provided file, in YAML
 buildentry() {
 	local file=$1
 
@@ -315,7 +315,7 @@ buildentry() {
 	fname=${file/%md/html} \
 	updated=$(git log --max-count=1 --format=format:%aI -- "$file") \
 	summary=$(yq --front-matter=extract '.summary' "$file") \
-		yq --null-input --output-format=yaml '
+		yq --null-input '
 			[{
 				"title": {
 					"+@type": "html",
@@ -348,7 +348,7 @@ buildentries() {
 	done
 }
 
-# Build Atom feed
+# Build Atom feed, in XML
 buildfeed() {
 	echo "Buiding Atom feed..." >&2
 

--- a/pbb
+++ b/pbb
@@ -314,7 +314,7 @@ buildentry() {
 	url=$(getconfvalue 'baseurl') \
 	fname=${file/%md/html} \
 	updated=$(git log --max-count=1 --format=format:%aI -- "$file") \
-	abstract=$(yq --front-matter=extract '.abstract' "$file") \
+	summary=$(yq --front-matter=extract '.summary' "$file") \
 		yq --null-input --output-format=yaml '
 			[{
 				"title": {
@@ -329,7 +329,7 @@ buildentry() {
 				},
 				"summary": {
 					"+@type": "html",
-					"+content": strenv(abstract)
+					"+content": strenv(summary)
 				}
 			}]
 		'
@@ -344,7 +344,7 @@ buildentries() {
 
 	local i
 	for ((i = 0; i < ${#files[@]}; ++i)); do
-		buildentry "${files[-(1 + i)]}"
+		buildentry "${files[-(1+i)]}"
 	done
 }
 

--- a/pbb
+++ b/pbb
@@ -34,13 +34,17 @@ die() {
 usage() {
 	cat <<- EOF >&2
 		usage:
-		pbb help | init TITLE | title TITLE | gccode CODE | build | serve | deploy
+		pbb help | init TITLE | set PROPERTY VALUE | build | serve | deploy
 		pbb enable FEATURE | disable FEATURE
 
 		   help     Display this message
 		   init     Initialize new blog in empty Git repository
-		   title    Set new blog title
-		   gccode   Set GoatCounter code to enable analytics
+		   set      Set configuration property to value; valid properties are
+		            title        Set now blog title
+		            gccode       Set GoatCounter code to enable analytics 
+		            baseurl      Set base URL for use in Atom feed
+		            authorname   Author name for Atom feed
+		            authoremail  Author email for Atom feed
 		   build    Generate HTML files and store them in docs directory
 		   serve    Serve blog on localhost:8000
 		   deploy   Commit changes in docs directory and push to remote
@@ -463,18 +467,18 @@ main() {
 			init "${*:2}"
 			;;
 
-		title)
-			if (($# < 2)); then
-				die "usage: pbb title TITLE"
+		set)
+			if (($# < 3)); then
+				die "usage: pbb set PROPERTY VALUE"
 			fi
-			setblogtitle "${*:2}"
-			;;
 
-		gccode)
-			if (($# < 2)); then
-				die "usage: pbb gccode CODE"
-			fi
-			setgccode "$2"
+			local property=$2
+			case $property in
+				title) setblogtitle "${*:3}" ;;
+				gccode) setgccode "$3" ;;
+				baseurl | authorname | authoremail) setconfvalue "$property" "$3" ;;
+				*) die "invalid property \"$3\"" ;;
+			esac
 			;;
 
 		enable)

--- a/pbb
+++ b/pbb
@@ -8,7 +8,7 @@ declare -r \
 	calicon='assets/calendar.svg' \
 	cssfile='assets/pbb.css' \
 	favicon='includes/favicon.html' \
-	fontlinks='includes/fontlinks.html' \
+	headerlinks='includes/headerlinks.html' \
 	feedpath='docs/feed.xml' \
 	goatcounter='includes/goatcounter.html' \
 	header='includes/header.html' \
@@ -112,7 +112,13 @@ init() {
 		'<link href="https://fonts.googleapis.com/css?family=' \
 		'Source+Code+Pro:400,400i,700,700i|Source+Sans+Pro:400,400i,700,700i' \
 		'&display=swap" rel="stylesheet">' \
-		> "$fontlinks"
+		> "$headerlinks"
+
+	# Atom feed link
+	printf '%s %s\n' \
+		'<link href="/feed.xml" type="application/atom+xml" rel="alternate"' \
+	   	"title=\"$blogtitle Feed\">" >> "$headerlinks"
+
 
 	# Favicon for header
 	printf '%s\n' \
@@ -177,7 +183,7 @@ md2html() {
 		"--from=markdown+emoji"
 		"--highlight-style=${XDG_DATA_HOME:-$HOME/.local/share}/pandoc/solarizeddark.theme"
 		"--include-before-body=$header"
-		"--include-in-header=$fontlinks"
+		"--include-in-header=$headerlinks"
 		"--lua-filter=dotgraph.lua"
 		"--metadata=document-css:true"
 		"--metadata=lang:$(getlang)"

--- a/pbb
+++ b/pbb
@@ -153,6 +153,11 @@ init() {
 
 	# Example post
 	cat <<- EOF > "$(printf '%(%F)T' -1)-my-first-post.md"
+		---
+		summary: >-
+		  A wild post appeared
+		---
+
 		# My first post
 
 		Hello world!

--- a/pbb
+++ b/pbb
@@ -184,7 +184,7 @@ md2html() {
 		"--output=docs/${file/%.md/.html}"
 		"--shift-heading-level-by=-1"
 		"--standalone"
-		"--table-of-contents"
+		"--table-of-contents=true"
 		"--to=html"
 		"--toc-depth=4"
 	)

--- a/pbb
+++ b/pbb
@@ -344,7 +344,7 @@ buildentries() {
 
 	local i
 	for ((i = 0; i < ${#files[@]}; ++i)); do
-		buildentry "${files[-(1+i)]}"
+		buildentry "${files[-(1 + i)]}"
 	done
 }
 

--- a/pbb
+++ b/pbb
@@ -335,10 +335,13 @@ buildentry() {
 		'
 }
 
-# Build feed entries for the 10 most recent posts
+# Build feed entries, truncate to 10 most recent posts, reverse chronologically
 buildentries() {
 	local files=(????-??-??-*.md)
-	files=("${files[@]: -10}")
+	if ((${#files[@]} > 10)); then
+		files=("${files[@]: -10}")
+	fi
+
 	local i
 	for ((i = 0; i < ${#files[@]}; ++i)); do
 		buildentry "${files[-(1+i)]}"

--- a/pbb
+++ b/pbb
@@ -303,6 +303,85 @@ build() {
 	cp "$calicon" docs/images
 }
 
+# Build Atom feed entry for the provided file
+buildentry() {
+	local file=$1
+
+	title=$(extracttitle "$file") \
+	url=$(getconfvalue 'baseurl') \
+	fname=${file/%md/html} \
+	updated=$(git log --max-count=1 --format=format:%aI -- "$file") \
+	abstract=$(yq --front-matter=extract '.abstract' "$file") \
+		yq --null-input --output-format=yaml '
+			[{
+				"title": {
+					"+@type": "html",
+					"+content": strenv(title)
+				},
+				"id": strenv(url) + "/" + strenv(fname),
+				"updated": strenv(updated),
+				"content": {
+					"+@src": strenv(url) + "/" + strenv(fname),
+					"+@type": "text/html"
+				},
+				"summary": {
+					"+@type": "html",
+					"+content": strenv(abstract)
+				}
+			}]
+		'
+}
+
+# Build feed entries for the 10 most recent posts
+buildentries() {
+	local files=(????-??-??-*.md)
+	files=("${files[@]: -10}")
+	local i
+	for ((i = 0; i < ${#files[@]}; ++i)); do
+		buildentry "${files[-(1+i)]}"
+	done
+}
+
+# Build Atom feed
+buildfeed() {
+	title=$(getconfvalue 'blogtitle') \
+	url=$(getconfvalue 'baseurl') \
+	name=$(getconfvalue 'authorname') \
+	email=$(getconfvalue 'authoremail') \
+	entries=$(buildentries) \
+		yq --null-input --output-format=xml '
+			.+p_xml = "version=\"1.0\" encoding=\"utf-8\""
+			| .feed = {
+				"+@xmlns": "http://www.w3.org/2005/Atom",
+				"title": strenv(title),
+				"id": strenv(url) + "/",
+				"updated": now,
+				"author": {
+					"name": strenv(name),
+					"email": strenv(email),
+					"uri": strenv(url) + "/"
+				},
+				"link": [
+					{
+						"+@href": strenv(url) + "/feed.xml",
+						"+@rel": "self",
+						"+@type": "application/atom+xml"
+					},
+					{
+						"+@href": strenv(url) + "/",
+						"+@rel": "alternate",
+						"+@type": "text/html"
+					}
+				],
+				"generator": {
+					"+@uri": "https://bewuethr/pandoc-bash-blog",
+					"+content": "pandoc-bash-blog"
+				},
+				"entry": env(entries)
+			}
+		'
+}
+
 # Monitor directory for file modifications and print names of modified files
 monitor() {
 	# Use unbuffered uniq to suppress multiple events within the same second,

--- a/pbb
+++ b/pbb
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-set -o errexit -o pipefail
 shopt -s extglob nullglob
 
+# Globals
 declare -r \
 	conf='.pbbconfig' \
 	calicon='assets/calendar.svg' \
@@ -13,7 +13,6 @@ declare -r \
 	header='includes/header.html' \
 	metadata='.metadata.yml'
 
-# shellcheck disable=SC2034
 declare -rA features=(
 	['math']=1
 	['bibliography']=1
@@ -75,7 +74,7 @@ checkgit() {
 
 	if [[ $PWD != "$topdir" ]]; then
 		warn "in git repo, but not in root directory"
-		echo 'run "pbb init" from the repository root'
+		echo "run \"pbb init\" from the repository root, $topdir"
 		return 1
 	fi
 
@@ -353,59 +352,67 @@ deploy() {
 	git push "${args[@]}"
 }
 
-if (($# < 1)); then
-	usage
-	exit 1
-fi
+main() {
+	set -o errexit -o pipefail
 
-subcmd=$1
-
-case $subcmd in
-	help) usage ;;
-
-	init)
-		if (($# < 2)); then
-			die "usage: pbb init TITLE"
-		fi
-		init "${*:2}"
-		;;
-
-	title)
-		if (($# < 2)); then
-			die "usage: pbb title TITLE"
-		fi
-		setblogtitle "${*:2}"
-		;;
-
-	gccode)
-		if (($# < 2)); then
-			die "usage: pbb gccode CODE"
-		fi
-		setgccode "$2"
-		;;
-
-	enable)
-		if (($# < 2)); then
-			die "usage: pbb enable FEATURE"
-		fi
-		setfeature "$2" 'on'
-		;;
-
-	disable)
-		if (($# < 2)); then
-			die "usage: pbb disable FEATURE"
-		fi
-		setfeature "$2" 'off'
-		;;
-
-	build) build ;;
-
-	serve) serve ;;
-
-	deploy) deploy ;;
-
-	*)
+	if (($# < 1)); then
 		usage
 		exit 1
-		;;
-esac
+	fi
+
+	local subcmd=$1
+
+	case $subcmd in
+		help) usage ;;
+
+		init)
+			if (($# < 2)); then
+				die "usage: pbb init TITLE"
+			fi
+			init "${*:2}"
+			;;
+
+		title)
+			if (($# < 2)); then
+				die "usage: pbb title TITLE"
+			fi
+			setblogtitle "${*:2}"
+			;;
+
+		gccode)
+			if (($# < 2)); then
+				die "usage: pbb gccode CODE"
+			fi
+			setgccode "$2"
+			;;
+
+		enable)
+			if (($# < 2)); then
+				die "usage: pbb enable FEATURE"
+			fi
+			setfeature "$2" 'on'
+			;;
+
+		disable)
+			if (($# < 2)); then
+				die "usage: pbb disable FEATURE"
+			fi
+			setfeature "$2" 'off'
+			;;
+
+		build) build ;;
+
+		serve) serve ;;
+
+		deploy) deploy ;;
+
+		*)
+			usage
+			exit 1
+			;;
+	esac
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+	main "$@"
+fi

--- a/pbb
+++ b/pbb
@@ -9,6 +9,7 @@ declare -r \
 	cssfile='assets/pbb.css' \
 	favicon='includes/favicon.html' \
 	fontlinks='includes/fontlinks.html' \
+	feedpath='docs/feed.xml' \
 	goatcounter='includes/goatcounter.html' \
 	header='includes/header.html' \
 	metadata='.metadata.yml'
@@ -299,7 +300,7 @@ build() {
 	md2html index.md
 
 	# Add Atom feed
-	buildfeed > docs/feed.xml
+	buildfeed > "$feedpath"
 
 	rm index.md
 	cp "$cssfile" docs

--- a/pbb
+++ b/pbb
@@ -40,9 +40,9 @@ usage() {
 		   help     Display this message
 		   init     Initialize new blog in empty Git repository
 		   set      Set configuration property to value; valid properties are
-		            title        Set now blog title
-		            gccode       Set GoatCounter code to enable analytics 
-		            baseurl      Set base URL for use in Atom feed
+		            title        New blog title
+		            gccode       GoatCounter code to enable analytics 
+		            baseurl      Base URL for use in Atom feed
 		            authorname   Author name for Atom feed
 		            authoremail  Author email for Atom feed
 		   build    Generate HTML files and store them in docs directory

--- a/pbb
+++ b/pbb
@@ -166,7 +166,6 @@ extracttitle() {
 # Convert a markdown file to HTML and store it in the docs directory
 md2html() {
 	local file=$1
-	local title=$2
 	[[ $file == *.md ]] || die "not a markdown file: $file"
 
 	echo "Building $file..." >&2
@@ -181,9 +180,9 @@ md2html() {
 		"--lua-filter=dotgraph.lua"
 		"--metadata=document-css:true"
 		"--metadata=lang:$(getlang)"
-		"--metadata=title:$(pandoc --to plain <<< "$title")"
 		"--metadata-file=.metadata.yml"
 		"--output=docs/${file/%.md/.html}"
+		"--shift-heading-level-by=-1"
 		"--standalone"
 		"--table-of-contents"
 		"--to=html"
@@ -214,8 +213,7 @@ md2html() {
 		args+=("--metadata=pagetitle:$(getconfvalue 'blogtitle')")
 	fi
 
-	# Delete level 1 heading because it's already printed as the title
-	pandoc "${args[@]}" <(sed '0,/^# /{/^# /d}' "$file") || die "error while converting $file"
+	pandoc "${args[@]}" "$file" || die "error while converting $file"
 }
 
 # Empty docs and copy images directory
@@ -288,17 +286,17 @@ build() {
 
 	# Build index file and convert posts
 	{
-		local f title
+		printf '%s\n' '# All posts'
+		local f
 		for f in ????-??-??-*.md; do
-			title=$(extracttitle "$f")
 			printf -- ':::\n[%s](%s)\n:::index-title\n\n:::\n%s\n:::index-date\n\n' \
-				"$title" "${f/%.md/.html}" "${f:0:10}"
-			md2html "$f" "$title"
+				"$(extracttitle "$f")" "${f/%.md/.html}" "${f:0:10}"
+			md2html "$f"
 		done | tac
 	} > index.md
 
 	# Convert index file
-	md2html index.md 'All posts'
+	md2html index.md
 
 	rm index.md
 	cp "$cssfile" docs
@@ -331,7 +329,7 @@ serve() {
 		case $fname in
 			./*.md)
 				echo "Rebuilding $fname..."
-				md2html "${fname#./}" "$(extracttitle "$fname")"
+				md2html "${fname#./}"
 				;;
 			./images/*)
 				echo "Copying $fname to images..."

--- a/pbb
+++ b/pbb
@@ -117,8 +117,7 @@ init() {
 	# Atom feed link
 	printf '%s %s\n' \
 		'<link href="/feed.xml" type="application/atom+xml" rel="alternate"' \
-	   	"title=\"$blogtitle Feed\">" >> "$headerlinks"
-
+		"title=\"$blogtitle Feed\">" >> "$headerlinks"
 
 	# Favicon for header
 	printf '%s\n' \

--- a/pbb
+++ b/pbb
@@ -298,6 +298,9 @@ build() {
 	# Convert index file
 	md2html index.md
 
+	# Add Atom feed
+	buildfeed > docs/feed.xml
+
 	rm index.md
 	cp "$cssfile" docs
 	cp "$calicon" docs/images
@@ -344,6 +347,8 @@ buildentries() {
 
 # Build Atom feed
 buildfeed() {
+	echo "Buiding Atom feed..." >&2
+
 	title=$(getconfvalue 'blogtitle') \
 	url=$(getconfvalue 'baseurl') \
 	name=$(getconfvalue 'authorname') \

--- a/test/feed.bats
+++ b/test/feed.bats
@@ -13,9 +13,10 @@ load test_helper
 	yq docs/feed.xml > /dev/null
 
 	# Feed has one entry
-	yq -o=yaml docs/feed.xml
+	yq docs/feed.xml
 	run yq '.feed | has("entry")' docs/feed.xml
 	echo "$output"
+	((status == 0))
 	[[ $output == 'true' ]]
 }
 
@@ -39,4 +40,16 @@ load test_helper
 	cat docs/????-??-??-*.html
 	grep -Fq '<link href="/feed.xml" type="application/atom+xml" rel="alternate" title="Testblog Feed">' \
 		docs/????-??-??-*.html
+}
+
+@test "The post summary appears on the feed" {
+	pbb init 'Testblog'
+	pbb build
+
+	yq docs/feed.xml
+	run yq '.feed.entry.summary.+content' docs/feed.xml
+
+	echo "$output"
+	((status == 0))
+	[[ $output = 'A wild post appeared' ]]
 }

--- a/test/feed.bats
+++ b/test/feed.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "Building creates an Atom feed" {
+	pbb init 'Testblog'
+	pbb build
+
+	# File exists
+	[[ -s docs/feed.xml ]]
+
+	# File is well-formed
+	yq docs/feed.xml > /dev/null
+
+	# Feed has one entry
+	yq -o=yaml docs/feed.xml
+	run yq '.feed | has("entry")' docs/feed.xml
+	echo "$output"
+	[[ $output == 'true' ]]
+}
+
+@test "Feed-specific properties are set correctly" {
+	pbb init 'Testblog'
+	pbb set authorname 'Grace Hopper'
+	pbb set authoremail 'grace@example.com'
+	pbb set baseurl 'https://graceblogs.com'
+	pbb build
+
+	[[ $(yq '.feed.title' docs/feed.xml) == 'Testblog' ]]
+	[[ $(yq '.feed.author.name' docs/feed.xml) == 'Grace Hopper' ]]
+	[[ $(yq '.feed.author.email' docs/feed.xml) == 'grace@example.com' ]]
+	[[ $(yq '.feed.author.uri' docs/feed.xml) == 'https://graceblogs.com/' ]]
+}
+
+@test "Post header has a link to the Atom feed" {
+	pbb init 'Testblog'
+	pbb build
+
+	cat docs/????-??-??-*.html
+	grep -Fq '<link href="/feed.xml" type="application/atom+xml" rel="alternate" title="Testblog Feed">' \
+		docs/????-??-??-*.html
+}

--- a/test/gccode.bats
+++ b/test/gccode.bats
@@ -3,16 +3,16 @@
 load test_helper
 
 @test "Complain about gccode without code" {
-	run pbb gccode
+	run pbb set gccode
 	((status == 1))
-	want="usage: pbb gccode CODE"
+	want="usage: pbb set PROPERTY VALUE"
 	printf '%s\n%s\n' "got: $output" "want: $want"
 	[[ $output == *$want* ]]
 }
 
 @test "Set initial GoatCounter code" {
 	pbb init "Testblog"
-	run pbb gccode 'mycode'
+	run pbb set gccode 'mycode'
 	pbb build
 
 	echo "$output"
@@ -31,9 +31,9 @@ load test_helper
 
 @test "Set GoatCounter code, then change it" {
 	pbb init "Testblog"
-	pbb gccode 'mycode'
+	pbb set gccode 'mycode'
 	pbb build
-	run pbb gccode 'anothercode'
+	run pbb set gccode 'anothercode'
 	pbb build
 
 	echo "$output"
@@ -52,9 +52,9 @@ load test_helper
 
 @test "Set GoatCounter code, then set it to empty" {
 	pbb init "Testblog"
-	pbb gccode 'mycode'
+	pbb set gccode 'mycode'
 	pbb build
-	run pbb gccode ''
+	run pbb set gccode ''
 	pbb build
 
 	echo "$output"
@@ -75,9 +75,9 @@ load test_helper
 
 @test "Set GoatCounter to code empty, then non-empty" {
 	pbb init "Testblog"
-	pbb gccode ''
+	pbb set gccode ''
 	pbb build
-	run pbb gccode 'mycode'
+	run pbb set gccode 'mycode'
 	pbb build
 
 	echo "$output"

--- a/test/init.bats
+++ b/test/init.bats
@@ -37,11 +37,11 @@ load test_helper
 	[[ -L assets/pbb.css ]]
 	[[ -L assets/calendar.svg ]]
 
-	# Font links file exists
-	fontlinks='includes/fontlinks.html'
-	[[ -s $fontlinks ]]
-	grep -Fq 'https://fonts.gstatic.com' "$fontlinks"
-	grep -Fq 'https://fonts.googleapis.com' "$fontlinks"
+	# Header links file exists
+	headerlinks='includes/headerlinks.html'
+	[[ -s $headerlinks ]]
+	grep -Fq 'https://fonts.gstatic.com' "$headerlinks"
+	grep -Fq 'https://fonts.googleapis.com' "$headerlinks"
 
 	# Favicon header include exists
 	favicon='includes/favicon.html'

--- a/test/title.bats
+++ b/test/title.bats
@@ -3,16 +3,16 @@
 load test_helper
 
 @test "Complain about title without title" {
-	run pbb title
+	run pbb set title
 	((status == 1))
-	want="usage: pbb title TITLE"
+	want="usage: pbb set PROPERTY VALUE"
 	printf '%s\n%s\n' "got: $output" "want: $want"
 	[[ $output == *$want* ]]
 }
 
 @test "Change to simple title" {
 	pbb init 'Testblog'
-	run pbb title 'New Title'
+	run pbb set title 'New Title'
 
 	echo "$output"
 	((status == 0))
@@ -26,7 +26,7 @@ load test_helper
 
 @test "Change to title with quotes" {
 	pbb init 'Testblog'
-	run pbb title "Example Man's \"Blog\""
+	run pbb set title "Example Man's \"Blog\""
 
 	echo "$output"
 	((status == 0))
@@ -42,7 +42,7 @@ load test_helper
 
 @test "Change title without quoting parameters" {
 	pbb init 'Testblog'
-	run pbb title New Title without Quotes
+	run pbb set title New Title without Quotes
 
 	echo "$output"
 	((status == 0))


### PR DESCRIPTION
And some refactoring:

- Make source-able by adding `main` function
- Bump pandoc and bats version in CI
- Fix captions / figures for dot graph generator
- Switch to shifting heading levels instead of extracting and deleting top-level heading

Still to do:

- [x] Add link to feed from each page
- [x] Update init process for new config values
- [x] Add tests
- [x] Update documentation