### PR TITLE
Use setup actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,9 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Install Pandoc
-        uses: r-lib/actions/setup-pandoc@v2.10.1
+        uses: pandoc/actions/setup@v1.1.0
         with:
-          pandoc-version: 3.1.6.1
+          version: 3.5
 
       - name: Get Bats repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,21 +25,11 @@ jobs:
         with:
           version: 3.5
 
-      - name: Get Bats repository
-        uses: actions/checkout@v4.2.2
-        with:
-          repository: bats-core/bats-core
-          ref: v1.11.0
-          path: bats-core
+      - name: Install Bats
+        uses: bats-core/bats-action@3.0.0
 
-      - name: Install dependencies
+      - name: Install other dependencies
         run: |
-          echo "::group::Install BATS"
-          cd bats-core
-          ./install.sh "$HOME"
-          printf '%s\n' "$HOME/bin" "$HOME/.local/bin" >> "$GITHUB_PATH"
-          echo "::endgroup::"
-
           echo "::group::Install graphviz"
           sudo apt-get install graphviz
           echo "::endgroup::"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,14 @@ jobs:
           version: 3.5
 
       - name: Install Bats
+        id: setup-bats
         uses: bats-core/bats-action@3.0.0
+        with:
+          bats-version: v1.11.0
+          support-path: ${{ github.workspace }}/tests/bats-support
+          assert-path: ${{ github.workspace }}/tests/bats-assert
+          detik-path: ${{ github.workspace }}/tests/bats-detik
+          file-path: ${{ github.workspace }}/tests/bats-file
 
       - name: Install other dependencies
         run: |
@@ -39,4 +46,6 @@ jobs:
           echo "::endgroup::"
 
       - name: Run tests
+        env:
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
         run: bats --tap test

--- a/test/bibliography.bats
+++ b/test/bibliography.bats
@@ -24,6 +24,7 @@ load test_helper
 	cat docs/????-??-??-*.html
 	grep -Pqz 'data-cites="Ritchie1974">\(Ritchie\sand\sThompson\s1974\)' docs/????-??-??-*.html
 
-	# Post contains bibliography
-	grep -q 'id="bibliography".*>Bibliography</h1>' docs/????-??-??-*.html
+	# Post contains bibliography; not a heading until jgm/pandoc#10367 is fixed
+	# grep -q 'id="bibliography".*>Bibliography</h1>' docs/????-??-??-*.html
+	grep -q '<p>Bibliography</p>' docs/????-??-??-*.html
 }


### PR DESCRIPTION
Use official actions to set up pandoc and Bats.

With the latest version of pandoc, the bibliography section title isn't a heading any longer because of jgm/pandoc#10367, so this PR also updates a test for now.