### PR TITLE
Fix bibliography heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ the `bibliography` feature:
 pbb enable bibliography
 ```
 
+The bibliography is appended to the end of a post. If you want a heading for
+it, just add one to the end of the post.
+
 [`--citeproc`]: <https://pandoc.org/MANUAL.html#citations>
 
 ### dot graphs

--- a/man/pbb.1
+++ b/man/pbb.1
@@ -226,11 +226,8 @@ pandoc documentation
 for details regarding the format and location of the bibliography as well as how
 citations work.
 .PP
-The heading of the bibliography defaults to \*(lqBibliography\*(rq and can be
-adjusted by modifying the value of
-.I reference-section-title
-in
-.IR .metadata.yml .
+If you want a heading for the reference section, add one to the end of the
+Markdown.
 .SS dot graphs
 When a code block has the class
 .IR dot ,
@@ -265,10 +262,9 @@ to modify its contents.
 .TP
 .I .metadata.yml
 Stores metadata used by pandoc such as the heading for the table of contents,
-the field that controls generation of the table of contents (which can be
+and the field that controls generation of the table of contents (which can be
 overridden per post, see
-.BR OPTIONS ),
-and the heading for the bibliography.
+.BR OPTIONS ).
 .TP
 .I assets
 Contains various assets used when the blog is built:

--- a/pbb
+++ b/pbb
@@ -140,7 +140,6 @@ init() {
 	printf '%s\n' \
 		'toc: false' \
 		'toc-title: Table of contents' \
-		'reference-section-title: Bibliography' \
 		> "$metadata"
 	git add "$metadata"
 

--- a/test/bibliography.bats
+++ b/test/bibliography.bats
@@ -13,6 +13,8 @@ load test_helper
 		# My first post
 
 		Blah blah [@Ritchie1974].
+
+		## Bibliography
 	EOF
 
 	run pbb build
@@ -24,7 +26,6 @@ load test_helper
 	cat docs/????-??-??-*.html
 	grep -Pqz 'data-cites="Ritchie1974">\(Ritchie\sand\sThompson\s1974\)' docs/????-??-??-*.html
 
-	# Post contains bibliography; not a heading until jgm/pandoc#10367 is fixed
-	# grep -q 'id="bibliography".*>Bibliography</h1>' docs/????-??-??-*.html
-	grep -q '<p>Bibliography</p>' docs/????-??-??-*.html
+	# Post contains bibliography
+	grep -q 'id="bibliography".*>Bibliography</h1>' docs/????-??-??-*.html
 }

--- a/test/init.bats
+++ b/test/init.bats
@@ -22,10 +22,9 @@ load test_helper
 	# Conf file contains title
 	grep -Fqx 'blogtitle=Testblog' .pbbconfig
 
-	# Metadata file contains TOC and bibliography settings
+	# Metadata file contains TOC settings
 	grep -Fqx 'toc: false' .metadata.yml
 	grep -Fqx 'toc-title: Table of contents' .metadata.yml
-	grep -Fqx 'reference-section-title: Bibliography' .metadata.yml
 
 	# Header file contains title
 	[[ $(< includes/header.html) == '<div id="blogtitle"><a href="./">Testblog</a></div>' ]]


### PR DESCRIPTION
After upgrading to pandoc 3.5, the bibliography heading stopped being a heading due to a change in jgm/pandoc@3d902349d1f8fd9a54539f8e16772c781dbd1063. I thought the behaviour was a bug and filed jgm/pandoc#10367, but it's behaviour as expected, and the workaround is simple: just add a heading manually. This PR removes the metadata setting for the reference section heading, along with documentation and test updates.